### PR TITLE
Fix Yandex Disk API file download script

### DIFF
--- a/.github/workflows/yadisk-sync.yml
+++ b/.github/workflows/yadisk-sync.yml
@@ -31,21 +31,80 @@ jobs:
 
       - name: Find and download file
         run: |
+          set -euo pipefail
+
           API_BASE="https://cloud-api.yandex.net/v1/disk/public/resources"
 
           echo "::notice::Listing directory contents"
           LIST_URL="$API_BASE?public_key=$(printf '%s' "$PUBLIC_URL" | jq -sRr @uri)&limit=1000"
 
+          # Fetch directory listing with error handling
+          echo "::debug::Requesting: $LIST_URL"
+          LIST_RESPONSE=$(curl -sS -w "\n%{http_code}" "$LIST_URL")
+          HTTP_CODE=$(echo "$LIST_RESPONSE" | tail -n1)
+          LIST_JSON=$(echo "$LIST_RESPONSE" | sed '$d')
+
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "::error::API request failed with HTTP $HTTP_CODE"
+            echo "::debug::Response: $LIST_JSON"
+            exit 1
+          fi
+
+          # Validate response structure
+          if ! echo "$LIST_JSON" | jq -e '._embedded.items' > /dev/null 2>&1; then
+            echo "::error::Invalid API response structure"
+            echo "::debug::Response: $LIST_JSON"
+            exit 1
+          fi
+
           echo "::notice::Finding file: $TARGET_NAME"
-          FILE_PATH=$(curl -sS "$LIST_URL" | jq -r --arg name "$TARGET_NAME" '._embedded.items[] | select(.type == "file" and .name == $name) | .path')
+          FILE_PATH=$(echo "$LIST_JSON" | jq -r --arg name "$TARGET_NAME" '
+            ._embedded.items[] |
+            select(.type == "file" and .name == $name) |
+            .path
+          ')
+
+          if [ -z "$FILE_PATH" ]; then
+            echo "::error::File not found: $TARGET_NAME"
+            echo "::debug::Available files:"
+            echo "$LIST_JSON" | jq -r '._embedded.items[] | select(.type == "file") | .name'
+            exit 1
+          fi
+
+          echo "::debug::Found file path: $FILE_PATH"
 
           echo "::notice::Getting download URL"
           DOWNLOAD_URL="$API_BASE/download?public_key=$(printf '%s' "$PUBLIC_URL" | jq -sRr @uri)&path=$(printf '%s' "$FILE_PATH" | jq -sRr @uri)"
-          HREF=$(curl -sS "$DOWNLOAD_URL" | jq -r '.href')
+
+          # Fetch download URL with error handling
+          echo "::debug::Requesting: $DOWNLOAD_URL"
+          DOWNLOAD_RESPONSE=$(curl -sS -w "\n%{http_code}" "$DOWNLOAD_URL")
+          HTTP_CODE=$(echo "$DOWNLOAD_RESPONSE" | tail -n1)
+          DOWNLOAD_JSON=$(echo "$DOWNLOAD_RESPONSE" | sed '$d')
+
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "::error::Download URL request failed with HTTP $HTTP_CODE"
+            echo "::debug::Response: $DOWNLOAD_JSON"
+            exit 1
+          fi
+
+          HREF=$(echo "$DOWNLOAD_JSON" | jq -r '.href')
+
+          if [ -z "$HREF" ] || [ "$HREF" = "null" ]; then
+            echo "::error::Failed to get download URL"
+            echo "::debug::Response: $DOWNLOAD_JSON"
+            exit 1
+          fi
+
+          echo "::debug::Download URL: $HREF"
 
           echo "::notice::Downloading file to: $DEST_PATH/$DEST_FILENAME"
           mkdir -p "$DEST_PATH"
-          curl -sS -o "$DEST_PATH/$DEST_FILENAME" "$HREF"
+
+          if ! curl -sS -o "$DEST_PATH/$DEST_FILENAME" "$HREF"; then
+            echo "::error::Failed to download file"
+            exit 1
+          fi
 
           SIZE=$(stat -c%s "$DEST_PATH/$DEST_FILENAME" 2>/dev/null || stat -f%z "$DEST_PATH/$DEST_FILENAME")
           echo "::notice::Downloaded $(numfmt --to=iec-i --suffix=B $SIZE 2>/dev/null || echo "$SIZE bytes")"


### PR DESCRIPTION
This fixes the "Cannot iterate over null" error by adding comprehensive error handling for all API requests.

Changes:
- Validate HTTP status codes before processing responses (expect 200)
- Check response structure exists before attempting to parse with jq
- Add null checks for all extracted values (FILE_PATH, HREF)
- Include detailed debug output for troubleshooting
- Provide clear error messages with context

The fix ensures API failures are caught early with actionable error messages instead of cryptic jq parsing errors.

# Summary

Briefly explain the changes and the motivation.

# Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs/Chore
- [ ] CI/CD

# Linked issues
Fixes #

# How to test
Describe steps to test locally.

# Checklist
- [ ] I ran linting (bun run lint) and typecheck (bun run typecheck)
- [ ] I ran tests (bun test) and they pass
- [ ] I updated docs/README if needed
- [ ] No secrets or sensitive data committed
- [ ] Backwards compatible or documented breaking changes
- [ ] I added screenshots or logs for UI/UX changes (if applicable)

# Screenshots

# Release notes
Brief, user-facing summary of the change.
